### PR TITLE
Return promise for refreshToken so that caller can wait for the new token

### DIFF
--- a/src/VueGapi/GoogleAuthService.js
+++ b/src/VueGapi/GoogleAuthService.js
@@ -204,6 +204,8 @@ export default class GoogleAuthService {
    * @method GoogleAuthService#refreshToken
    * @see [GoogleUser.reloadAuthResponse]{@link https://developers.google.com/identity/sign-in/web/reference#googleuserreloadauthresponse}
    *
+   * @return {Promise}
+   *
    * @example
    * <script>
    *     name: 'App'
@@ -222,8 +224,16 @@ export default class GoogleAuthService {
   refreshToken() {
     if (!this.authInstance) throw new Error('gapi not initialized')
     const GoogleUser = this.authInstance.currentUser.get()
-    GoogleUser.reloadAuthResponse().then((authResult) => {
-      this._setStorage(authResult)
+    return new Promise((res, rej) => {
+      GoogleUser.reloadAuthResponse()
+        .then((authResult) => {
+          this._setStorage(authResult)
+          res()
+        })
+        .catch((error) => {
+          console.error(error)
+          rej(error)
+        })
     })
   }
 

--- a/src/VueGapi/GoogleAuthService.js
+++ b/src/VueGapi/GoogleAuthService.js
@@ -224,16 +224,9 @@ export default class GoogleAuthService {
   refreshToken() {
     if (!this.authInstance) throw new Error('gapi not initialized')
     const GoogleUser = this.authInstance.currentUser.get()
-    return new Promise((res, rej) => {
-      GoogleUser.reloadAuthResponse()
-        .then((authResult) => {
-          this._setStorage(authResult)
-          res()
-        })
-        .catch((error) => {
-          console.error(error)
-          rej(error)
-        })
+    return GoogleUser.reloadAuthResponse().then((authResult) => {
+      this._setStorage(authResult)
+      return authResult
     })
   }
 


### PR DESCRIPTION
Existing `GoogleAuthServive.refreshToken()` method makes async API call to refresh the token. If the caller wants to wait for the token to be refreshed for some reason then there is no such infra as refreshToken() will return way before the local storage is updated with new tokens.
This PR deals with returning a *Promise* from `refreshToken()` so that if any app wants to wait for the token to be refreshed, they can do it easily.