### PR TITLE
Don't calculate expire timestamp manually

### DIFF
--- a/src/GoogleAuthService/utils.js
+++ b/src/GoogleAuthService/utils.js
@@ -18,18 +18,6 @@ export function sessionFromAuthResponse(authResponse) {
   return {
     accessToken: authResponse.access_token,
     idToken: authResponse.id_token,
-    expiresAt: expiresAt(authResponse),
+    expiresAt: authResponse.expires_at,
   }
-}
-
-/**
- * Return the expiration time of the user's auth session.
- *
- * @private
- * @param {object} authResponse gapi.auth2.AuthResponse object
- *
- * @return {number}
- */
-export function expiresAt(authResponse) {
-  return authResponse.expires_in * 1000 + Date.now()
 }

--- a/test/mocks/GoogleUserMock.js
+++ b/test/mocks/GoogleUserMock.js
@@ -136,12 +136,11 @@ export default class GoogleUserMock {
 
   getAuthResponse(includeAuthorizationData) {
     const res = {
-      expires_in: 123456,
       access_token: 'ACCESS_TOKEN',
       id_token: 'ID_TOKEN',
       scope: 'SCOPE',
       first_issued_at: 1,
-      expires_at: 1,
+      expires_at: Date.now() + 123456000,
     }
 
     if (!includeAuthorizationData) {


### PR DESCRIPTION
The token expire timestamp can be retrieved from the auth response and doesn't have to be calculated by us.